### PR TITLE
Adjust flops benchmark

### DIFF
--- a/kernels.h
+++ b/kernels.h
@@ -72,9 +72,8 @@ __global__ void HBM_bw(T *dst, const T *src)
     dst[gid] = src[gid];
 }
 
-
 template<typename T, int nFMA>
-__global__ void flops_benchmark(T *buf, uint32_t nSize)
+__global__ void flops_benchmark(T *buf, uint32_t nSize, T randNum)
 {
     const uint32_t gid = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
     const uint32_t nThreads  = gridDim.x * blockDim.x;
@@ -82,10 +81,10 @@ __global__ void flops_benchmark(T *buf, uint32_t nSize)
     const uint32_t maxOffset = nEntriesPerThread * nThreads;
 
     T *ptr;
-    const T y = (T) 1.0;
+    const T y = (T) randNum;
 
     ptr = &buf[gid];
-    T x = (T) 2.0;
+    T x = (T) 3.0;
 
     for(uint32_t offset=0; offset < maxOffset; offset += nThreads)
     {

--- a/kernels.h
+++ b/kernels.h
@@ -81,9 +81,12 @@ __global__ void flops_benchmark(T *buf, uint32_t nSize, T randNum)
     const uint32_t maxOffset = nEntriesPerThread * nThreads;
 
     T *ptr;
+    // Using a random fp number generated prior for addition
     const T y = (T) randNum;
 
     ptr = &buf[gid];
+    // Using 3.0 as buffer multiplier to avoid output modifier application
+    // See 6.2.2 in MI300 ISA (https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf)
     T x = (T) 3.0;
 
     for(uint32_t offset=0; offset < maxOffset; offset += nThreads)

--- a/roofline.cpp
+++ b/roofline.cpp
@@ -182,10 +182,8 @@ int main(int argc, char **argv)
     using archs_t = std::map<std::string, datatypes>;
     datatypes unsupported_datatypes;
 
-    /*  supported_archs indicates which archs are supported by rocm-amdgpu-bench,
-    *   and the corresponding datatypes which ARE NOT supported by the arch
-    */
-    archs_t supported_archs = {
+    /* supported_archs_unsupported_dt indicates supported archs and the corrseponding datatypes which ARE NOT supported by each arch */
+    archs_t supported_archs_unsupported_dt = {
         {"gfx908", {"MALL", "FP8", "MFMA-F8", "MFMA-F64"}}, // MI100 series
         {"gfx90a", {"MALL", "FP8", "MFMA-F8"}},             // MI200 series
         {"gfx940", {"MFMA-BF16", "MFMA-I8"}},               // MI300A_A0
@@ -197,7 +195,7 @@ int main(int argc, char **argv)
     {
         auto gcnArch = device_arch(devID);
         quiet = false;
-        if (auto search = supported_archs.find(gcnArch); search == supported_archs.end())
+        if (auto search = supported_archs_unsupported_dt.find(gcnArch); search == supported_archs_unsupported_dt.end())
         {
             printf("Unsupported device architecture \"%s\" will be skipped\n", gcnArch.c_str());
         }
@@ -244,8 +242,8 @@ int main(int argc, char **argv)
 
         /* Skip incompatible devices */
         auto gcnArch = device_arch(dev);
-        auto searchArch = supported_archs.find(gcnArch);
-        if ((searchArch == supported_archs.end()) || ((devID >= 0) && (dev != devID)))
+        auto searchArch = supported_archs_unsupported_dt.find(gcnArch);
+        if ((searchArch == supported_archs_unsupported_dt.end()) || ((devID >= 0) && (dev != devID)))
         {
             printf("GPU Device %d: Skipped\n", dev);
             continue;


### PR DESCRIPTION
Modify flops_benchmark to multiply matrix by a different number, and pass a random fp number for adding.
Also cleaned up datatype support checking per gpu.