### PR TITLE
Add `experiments` CLI arg

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 const char ver[] = "v1.0";
 void help(void)
 {
-    printf("Usage: roofline [-d DEVIVCE] [-o csvfile.csv]\n");
+    printf("Usage: roofline [-d DEVICE] [-o csvfile.csv]\n");
     printf("Version: %s\n", ver);
     printf("\n\n optional arguments:\n");
     printf("\n -h, --help           Show this help message and exit\n");
@@ -79,7 +79,7 @@ void stats(float *samples, int entries, float *mean, float *stdev, float *confid
     mean[0] = mean_val;
     stdev[0] = stdev_val;
     confidence[0] = 1.960 * stdev_val / sqrtf(entries);
-    
+
 }
 
 std::string device_arch(int device_id){

--- a/roofline.cpp
+++ b/roofline.cpp
@@ -137,7 +137,7 @@ int main(int argc, char **argv)
     // CLI parsing
     while (1)
     {
-        c = getopt_long(argc, argv, "d:w:i:s:o:hvq", long_options, &option_index);
+        c = getopt_long(argc, argv, "d:w:i:s:o:e:hvq", long_options, &option_index);
 
         /* Detect the end of the options. */
         if (c == -1)
@@ -160,6 +160,9 @@ int main(int argc, char **argv)
             break;
         case 'i':
             numIters = atoi(optarg);
+            break;
+        case 'e':
+            numExperiments = atoi(optarg);
             break;
         case 'o':
             csvFile = optarg;
@@ -334,7 +337,7 @@ int main(int argc, char **argv)
          *
          * **********************************************/
 
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         int cacheSize = arch_sizes[gcnArch].MALL_size;
         if (auto search = unsupported_datatypes.find("MALL"); search != unsupported_datatypes.end())
@@ -405,7 +408,7 @@ int main(int argc, char **argv)
          *
          * **********************************************/
 
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         cacheSize = arch_sizes[gcnArch].L2_size;
         HIP_ASSERT(hipMalloc(&memBlock, cacheSize));
         HIP_ASSERT(hipMalloc(&dummy, workgroupSize * sizeof(float)));
@@ -463,7 +466,7 @@ int main(int argc, char **argv)
          * L1 BW benchmarking
          *
          * **********************************************/
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         cacheSize = arch_sizes[gcnArch].L1_size;
         HIP_ASSERT(hipMalloc(&memBlock, cacheSize));
         HIP_ASSERT(hipMalloc(&dummy, workgroupSize * sizeof(float)));
@@ -521,7 +524,7 @@ int main(int argc, char **argv)
          * LDS BW benchmarking
          *
          * **********************************************/
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         HIP_ASSERT(hipMalloc(&dummy, workgroupSize * sizeof(float)));
 
         // warm up first use default setting
@@ -573,7 +576,7 @@ int main(int argc, char **argv)
          *
          * **********************************************/
         int nSize = 0;
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         HIP_ASSERT(hipMalloc(&memBlock, DEFAULT_DATASET_SIZE));
 
         // warm up first use default setting
@@ -637,7 +640,7 @@ int main(int argc, char **argv)
         }
 
         /* FP16 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         if (auto search = unsupported_datatypes.find("FP16"); search != unsupported_datatypes.end())
         {
@@ -693,7 +696,7 @@ int main(int argc, char **argv)
         }
 
         /* BF16 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(hip_bfloat16) / numThreads * numThreads;
 
         hipLaunchKernelGGL((flops_benchmark<hip_bfloat16, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (hip_bfloat16 *)memBlock, nSize);
@@ -735,7 +738,7 @@ int main(int argc, char **argv)
         }
 
         /* FP32 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(float) / numThreads * numThreads;
 
         hipLaunchKernelGGL((flops_benchmark<float, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (float *)memBlock, nSize);
@@ -777,7 +780,7 @@ int main(int argc, char **argv)
         }
 
         /* FP64 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(double) / numThreads * numThreads;
         hipLaunchKernelGGL((flops_benchmark<double, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (double *)memBlock, nSize);
         HIP_ASSERT(hipDeviceSynchronize());
@@ -818,7 +821,7 @@ int main(int argc, char **argv)
         }
 
         /* INT8 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(int8_t) / numThreads * numThreads;
         hipLaunchKernelGGL((flops_benchmark<int8_t, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (int8_t *)memBlock, nSize);
         HIP_ASSERT(hipDeviceSynchronize());
@@ -859,7 +862,7 @@ int main(int argc, char **argv)
         }
 
         /* INT32 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(int32_t) / numThreads * numThreads;
         hipLaunchKernelGGL((flops_benchmark<int32_t, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (int32_t *)memBlock, nSize);
         HIP_ASSERT(hipDeviceSynchronize());
@@ -900,7 +903,7 @@ int main(int argc, char **argv)
         }
 
         /* INT64 benchmark */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         nSize = DEFAULT_DATASET_SIZE / sizeof(int64_t) / numThreads * numThreads;
         hipLaunchKernelGGL((flops_benchmark<int64_t, 1024>), dim3(numWorkgroups), dim3(workgroupSize), 0, 0, (int64_t *)memBlock, nSize);
         HIP_ASSERT(hipDeviceSynchronize());
@@ -954,7 +957,7 @@ int main(int argc, char **argv)
         numIters = 2000;
 
         /* MFMA-F8 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         if (auto search = unsupported_datatypes.find("MFMA-F8"); search != unsupported_datatypes.end())
         {
@@ -1004,7 +1007,7 @@ int main(int argc, char **argv)
         }
 
         /* MFMA-F16 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         totalFlops = (uint64_t)numWorkgroups * SIMDS_PER_CU * numIters * MFMA_F16_OPS;
         currBenchmark++;
         for (int n = 0; n < numExperiments; n++)
@@ -1041,7 +1044,7 @@ int main(int argc, char **argv)
         }
 
         /* MFMA-BF16 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         totalFlops = (uint64_t)numWorkgroups * SIMDS_PER_CU * numIters * MFMA_BF16_OPS;
         for (int n = 0; n < numExperiments; n++)
@@ -1057,7 +1060,7 @@ int main(int argc, char **argv)
                 showProgress((float)n / numExperiments);
             }
         }
-        
+
         stats(samples, numExperiments, &mean, &stdev, &confidence);
 
         perf_metrics.push_back(mean);
@@ -1078,7 +1081,7 @@ int main(int argc, char **argv)
         }
 
         /* MFMA-F32 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         totalFlops = (uint64_t)numWorkgroups * SIMDS_PER_CU * numIters * MFMA_F32_OPS;
         currBenchmark++;
         for (int n = 0; n < numExperiments; n++)
@@ -1113,9 +1116,9 @@ int main(int argc, char **argv)
             printf("\nPeak MFMA FLOPs (F32), GPU ID: %d, workgroupSize:%d, workgroups:%d, experiments:%d, FLOP:%lu, duration:%.1f ms, mean:%.1f GFLOPS, stdev=%.1f GFLOPS\n",
                    dev, workgroupSize, numWorkgroups, numExperiments, totalFlops, eventMs, mean, stdev);
         }
-        
+
         /* MFMA-F64 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         totalFlops = (uint64_t)numWorkgroups * SIMDS_PER_CU * numIters * MFMA_F64_OPS;
         if (auto search = unsupported_datatypes.find("MFMA-F64"); search != unsupported_datatypes.end())
@@ -1166,7 +1169,7 @@ int main(int argc, char **argv)
         }
 
         /* MFMA-I8 */
-        numExperiments = DEFAULT_NUM_EXPERIMENTS;
+
         currBenchmark++;
         totalFlops = (uint64_t)numWorkgroups * SIMDS_PER_CU * numIters * MFMA_I8_OPS;
         for (int n = 0; n < numExperiments; n++)


### PR DESCRIPTION
`--experiments` and `-e` are supposed to be available as CLI args, but this functionality was not implemented. This PR adds these as valid options. E.g., you can now run `./roofline -e 200` to run each kernel that many times.