### PR TITLE
Dynamic CU retrieval

### DIFF
--- a/common.cpp
+++ b/common.cpp
@@ -92,3 +92,9 @@ std::string device_arch(int device_id){
   }
   return device_arch;
 }
+
+int device_compute_units(int device_id) {
+    hipDeviceProp_t props;
+    HIP_ASSERT(hipGetDeviceProperties(&props, device_id));
+    return props.multiProcessorCount;
+}

--- a/common.h
+++ b/common.h
@@ -36,6 +36,7 @@ void showProgress(float percentage);
 void stats(float *samples, int entries, float *mean, float *stdev, float *confidence);
 
 std::string device_arch(int device_id);
+int device_compute_units(int device_id);
 
 static inline
 void initHipEvents(hipEvent_t &start, hipEvent_t &stop)

--- a/roofline.h
+++ b/roofline.h
@@ -17,44 +17,53 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef __GFX_ROOFLINE_COMMON_H__
-#define __GFX_ROOFLINE_COMMON_H__
+#ifndef __ROOFLINE_H__
+#define __ROOFLINE_H__
 
-#include <hip/hip_runtime.h>
-#include <string>
-#include <stdlib.h>
-#include <cstdio>
-#include <vector>
-#include <cassert>
+#if AMDGPU_TARGET == GFX90A
 
-//#define HIP_ASSERT(x) (assert((x)==hipSuccess))
-#define HIP_ASSERT(x) { auto ret = (x); if(ret != hipSuccess) { fprintf(stderr, "%s:%d :: HIP error : %s\n", __FILE__, __LINE__, hipGetErrorString(ret));  throw std::runtime_error("hip_error"); }}
+#define L2_CACHE_SIZE           (8*1024*1024)
+#define L1_CACHE_SIZE           (16*1024)
+#define LDS_SIZE                (65536)
+#else
 
-void help(void);
-void showProgress(float percentage);
+// Default settings
+#define L2_CACHE_SIZE           (8*1024*1024)
+#define L1_CACHE_SIZE           (16*1024)
+#define LDS_SIZE                (65536)
 
-void stats(float *samples, int entries, float *mean, float *stdev, float *confidence);
-
-std::string device_arch(int device_id);
-int device_compute_units(int device_id);
-
-static inline
-void initHipEvents(hipEvent_t &start, hipEvent_t &stop)
-{
-    HIP_ASSERT(hipEventCreate(&start));
-    HIP_ASSERT(hipEventCreate(&stop));
-    HIP_ASSERT(hipEventRecord(start));
-}
-
-
-static inline
-void stopHipEvents(float &eventMs, hipEvent_t &start, hipEvent_t &stop)
-{
-    HIP_ASSERT(hipEventRecord(stop));
-    HIP_ASSERT(hipEventSynchronize(stop));
-    HIP_ASSERT(hipEventElapsedTime(&eventMs, start, stop));
-    HIP_ASSERT(hipEventDestroy(start));
-    HIP_ASSERT(hipEventDestroy(stop));
-}
 #endif
 
+struct arch_size_specs {
+    uint64_t L1_size;
+    uint64_t L2_size;
+    uint64_t MALL_size;
+    uint64_t LDS_size;
+};
+
+enum {
+    MFMA_F4_OPS = 131072, // for f8f6f4 scaling mfma builting
+    MFMA_F6_OPS = 131072, // for f8f6f4 scaling mfma builting
+    MFMA_F8_OPS = 32768,
+    MFMA_F16_OPS  = 16384,
+    MFMA_F32_OPS  = 4096,
+    MFMA_F64_OPS  = 2048,
+#if AMDGPU_TARGET == GFX90A
+    MFMA_I8_OPS   = 16384,
+    MFMA_BF16_OPS = 8192,
+#else
+    MFMA_I8_OPS   = 32768,
+    MFMA_BF16_OPS = 16384,
+#endif
+};
+
+const int SIMDS_PER_CU = 4;
+
+const int DEFAULT_WORKGROUP_SIZE = 256;
+const int DEFAULT_WORKGROUPS     = 8192;
+const int DEFAULT_THREADS        = (DEFAULT_WORKGROUP_SIZE * DEFAULT_WORKGROUPS);
+const int DEFAULT_NUM_EXPERIMENTS = 100;
+const int DEFAULT_NUM_ITERS       = 10;
+const int DEFAULT_DATASET_SIZE    = (512 * 1024 * 1024);
+
+#endif //__ROOFLINE_H__


### PR DESCRIPTION
Previously, we mapped LLVM Target Name -> # of CUs. This did not work in the case of MI300A and MI300X which share arch `gfx942` but have differing # of CU's (228 vs 304).

This PR retrieves the #of CUs from `hipGetDeviceProperties` with the specific property, `multiProcessorCount`. 