### PR TITLE
Modify flops_benchmark

### DIFF
--- a/kernels.h
+++ b/kernels.h
@@ -82,7 +82,7 @@ __global__ void flops_benchmark(T *buf, uint32_t nSize)
     const uint32_t maxOffset = nEntriesPerThread * nThreads;
 
     T *ptr;
-    const T y = (T) 1.0;
+    const T y = (T) 1.1;
 
     ptr = &buf[gid];
     T x = (T) 2.0;


### PR DESCRIPTION
## Motivation

Adjusting flops benchmark- FP64 empirical now closely representing the theoretical specs.

## Technical Details

Higher output values caused by co-issuing and usage of special scalar operands.

## Test Plan

Manual testing after building roofline bins for rocprof-compute repo.

## Test Result

Previously tested and numbers verified by internal HPC team members.

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
