### PR TITLE
Remove obsolete gfx940 and gfx941 references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ string(REGEX REPLACE "([0-9]+)\.([0-9]+)\.([0-9]+)(.*)" "\\1.\\2.\\3" ROOFLINE_V
 
 # Set preferred compiler and supported targets
 set(CMAKE_HIP_COMPILER "amdclang++" CACHE STRING "desired c++ compiler" FORCE)
-set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx950" CACHE STRING "AMD GPU architectures" FORCE)
+set(CMAKE_HIP_ARCHITECTURES "gfx908;gfx90a;gfx942;gfx950" CACHE STRING "AMD GPU architectures" FORCE)
 
 # CMake modules
 list(APPEND CMAKE_MODULE_PATH ${ROCM_LIB}/cmake/hip ${ROCM_PATH}/lib/cmake/hip /opt/rocm/lib/cmake/hip /opt/rocm/hip/cmake)

--- a/kernels.cpp
+++ b/kernels.cpp
@@ -158,8 +158,8 @@ __global__ void mfma_f8f6f4(int iter, float *dummy, MX_DATAFORMATS datatype)
 
 __global__ void mfma_f8(int iter, float *dummy)
 {
-// MI300 series only - note gfx940/gfx941/gfx942 only uses fnuz f8
-#if defined(__gfx940__) or defined(__gfx941__) or defined(__gfx942__) or defined(__gfx950__)
+// MI300 series only - note gfx942 only uses fnuz f8
+#if defined(__gfx942__) or defined(__gfx950__)
     // Input: 2 F32 registers
     // builtin mfma expects double input
     double a =  threadIdx.x;

--- a/roofline.cpp
+++ b/roofline.cpp
@@ -47,8 +47,6 @@ int main(int argc, char **argv)
     arch_size_t arch_sizes;
     arch_sizes["gfx908"] = arch_size_specs{16 * 1024, 8 * 1024 * 1024, 0, /*          */ 64 * 1024}; // MI100
     arch_sizes["gfx90a"] = arch_size_specs{16 * 1024, 8 * 1024 * 1024, 0, /*          */ 64 * 1024}; // MI200 per die
-    arch_sizes["gfx940"] = arch_size_specs{32 * 1024, 4 * 1024 * 1024, 64 * 1024 * 1024, 64 * 1024}; // MI300A A0 (Obsolete)
-    arch_sizes["gfx941"] = arch_size_specs{32 * 1024, 4 * 1024 * 1024, 64 * 1024 * 1024, 64 * 1024}; // MI300X A0 (Obsolete)
     arch_sizes["gfx942"] = arch_size_specs{32 * 1024, 4 * 1024 * 1024, 64 * 1024 * 1024, 64 * 1024}; // MI300A/MI300X
     arch_sizes["gfx950"] = arch_size_specs{32 * 1024, 4 * 1024 * 1024, 64 * 1024 * 1024, 64 * 1024}; // MI355
 
@@ -58,22 +56,16 @@ int main(int argc, char **argv)
     cache_bw_kernel_selector_t L1_bw_kernel_selector;
     L1_bw_kernel_selector["gfx908"] = Cache_bw<float, 16 * 1024, 256>;
     L1_bw_kernel_selector["gfx90a"] = Cache_bw<float, 16 * 1024, 256>;
-    L1_bw_kernel_selector["gfx940"] = Cache_bw<float, 32 * 1024, 256>;
-    L1_bw_kernel_selector["gfx941"] = Cache_bw<float, 32 * 1024, 256>;
     L1_bw_kernel_selector["gfx942"] = Cache_bw<float, 32 * 1024, 256>;
     L1_bw_kernel_selector["gfx950"] = Cache_bw<float, 32 * 1024, 256>;
 
     cache_bw_kernel_selector_t L2_bw_kernel_selector;
     L2_bw_kernel_selector["gfx908"] = Cache_bw<float, 8 * 1024 * 1024, 256>;
     L2_bw_kernel_selector["gfx90a"] = Cache_bw<float, 8 * 1024 * 1024, 256>;
-    L2_bw_kernel_selector["gfx940"] = Cache_bw<float, 4 * 1024 * 1024, 256>;
-    L2_bw_kernel_selector["gfx941"] = Cache_bw<float, 4 * 1024 * 1024, 256>;
     L2_bw_kernel_selector["gfx942"] = Cache_bw<float, 4 * 1024 * 1024, 256>;
     L2_bw_kernel_selector["gfx950"] = Cache_bw<float, 4 * 1024 * 1024, 256>;
 
     cache_bw_kernel_selector_t MALL_bw_kernel_selector;
-    MALL_bw_kernel_selector["gfx940"] = Cache_bw<float, 64 * 1024 * 1024, 256>;
-    MALL_bw_kernel_selector["gfx941"] = Cache_bw<float, 64 * 1024 * 1024, 256>;
     MALL_bw_kernel_selector["gfx942"] = Cache_bw<float, 64 * 1024 * 1024, 256>;
     MALL_bw_kernel_selector["gfx950"] = Cache_bw<float, 64 * 1024 * 1024, 256>;
 
@@ -194,8 +186,6 @@ int main(int argc, char **argv)
     archs_t supported_archs_unsupported_dt = {
         {"gfx908", {"MALL", "FP16", "MFMA-F4", "MFMA-F6", "MFMA-F8", "MFMA-F64"}}, // MI100 series
         {"gfx90a", {"MALL", "MFMA-F4", "MFMA-F6", "MFMA-F8"}},             // MI200 series
-        {"gfx940", {"MFMA-F4", "MFMA-F6"}}, // MI300A_A0
-        {"gfx941", {"MFMA-F4", "MFMA-F6"}}, // MI300X_A0
         {"gfx942", {"MFMA-F4", "MFMA-F6"}}, // MI300A_A1, MI300X_A1, MI308
         {"gfx950", {}}, // MI350, MI355
     };


### PR DESCRIPTION
## Motivation

Latest rocm builds do not support gfx940 and gfx941 in CMAKE_HIP_ARCHITECTURES, removing all references in cmake and src files.

## Technical Details

## Test Plan

Manual testing.

## Test Result

Builds fine when removing references from CMAKE_HIP_ARCHITECTURES

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
